### PR TITLE
[FEAT] Creation of timestamp helper function

### DIFF
--- a/backend/dojo_examples/combat_game/src/helpers/timestamp.cairo
+++ b/backend/dojo_examples/combat_game/src/helpers/timestamp.cairo
@@ -1,0 +1,18 @@
+use combat_game::constants;
+use core::panic::panic_with_felt252;
+
+#[generate_trait]
+pub impl Timestamp of TimestampTrait {
+    fn unix_timestamp_to_day(timestamp: u64) -> u32 {
+        // calculate convertion
+        let days: u64 = timestamp / constants::SECONDS_PER_DAY;
+
+        match days.try_into() {
+            Result::Ok(day_u32) => day_u32,
+            // handle error of overflow in size
+            Result::Err(_) => {
+                panic_with_felt252('Timestamp conversion overflow');
+            }
+        }
+    }
+}

--- a/backend/dojo_examples/combat_game/src/helpers/timestamp.cairo
+++ b/backend/dojo_examples/combat_game/src/helpers/timestamp.cairo
@@ -16,3 +16,30 @@ pub impl Timestamp of TimestampTrait {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::TimestampTrait;
+    use combat_game::constants;
+    use core::panic::catch_panic;
+
+    #[test]
+    fn test_unix_timestamp_to_day_valid() {
+        // 2 days worth of seconds
+        let timestamp: u64 = 2 * constants::SECONDS_PER_DAY;
+        let day = TimestampTrait::unix_timestamp_to_day(timestamp);
+        assert(day == 2, 'Should return 2 days');
+    }
+
+    #[test]
+    fn test_unix_timestamp_to_day_overflow() {
+        // This timestamp will result in days > u32::MAX
+        let timestamp: u64 = (u32::MAX as u64 + 1) * constants::SECONDS_PER_DAY;
+        let result = catch_panic(|| {
+            TimestampTrait::unix_timestamp_to_day(timestamp);
+        });
+        assert(result.is_err(), 'Should panic on overflow');
+    }
+}
+
+


### PR DESCRIPTION
# [FEATURE] Implementation of Timestamp utility function

## 📝 Summary
In the helpers forlder in src of battle_project now there's a new file named `timestamp.cairo`, within this you'll find the implementation of a Timestamp trait with the required function.
To enhance the function and leave a control action in case of error, the function validates the `try_into` function and based in the result, it returns the expected number or panics to give an alert of overflow.

### Related Issues
- Closes #87 

### Type of Change
Mark with an `x` all the checkboxes that apply (like `[x]`).
- [ ] 📝 Documentation (updates to README, docs, or comments)
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 👌 Enhancement (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

## 🔄 Changes Made
### What's Changed
Creation of the expected file with the Timestamp trait.

### Implementation Details
The file is in a helpers folder within the main src directory of the project, so that it's easy to find and track when using it.

### Technical Notes
No test are provided yet. They are written but errors in other tests make the general test fail.

### Test Coverage
- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Testing

### Evidence
--

### Testing Notes
--

## 🔜 Next Steps
Clear the behaviour of tests and run the tests again